### PR TITLE
Add ChatMember update handler

### DIFF
--- a/anjani/core/telegram_bot.py
+++ b/anjani/core/telegram_bot.py
@@ -24,7 +24,12 @@ import pyrogram.filters as flt
 from aiopath import AsyncPath
 from pyrogram import Client
 from pyrogram.filters import Filter
-from pyrogram.handlers import CallbackQueryHandler, InlineQueryHandler, MessageHandler
+from pyrogram.handlers import (
+    CallbackQueryHandler,
+    ChatMemberUpdatedHandler,
+    InlineQueryHandler,
+    MessageHandler,
+)
 from pyrogram.types import CallbackQuery, InlineQuery, Message, User
 from yaml import full_load
 
@@ -37,7 +42,9 @@ if TYPE_CHECKING:
     from .anjani_bot import Anjani
 
 EventType = Union[CallbackQuery, InlineQuery, Message]
-TgEventHandler = Union[CallbackQueryHandler, InlineQueryHandler, MessageHandler]
+TgEventHandler = Union[
+    CallbackQueryHandler, InlineQueryHandler, MessageHandler, ChatMemberUpdatedHandler
+]
 
 
 class TelegramBot(MixinBase):
@@ -234,6 +241,7 @@ class TelegramBot(MixinBase):
         self.update_plugin_event(
             "chat_action", MessageHandler, filters=flt.new_chat_members | flt.left_chat_member
         )
+        self.update_plugin_event("chat_member_update", ChatMemberUpdatedHandler)
         self.update_plugin_event("chat_migrate", MessageHandler, filters=flt.migrate_from_chat_id)
         self.update_plugin_event("inline_query", InlineQueryHandler)
         self.update_plugin_event(

--- a/anjani/plugins/federation.py
+++ b/anjani/plugins/federation.py
@@ -24,6 +24,7 @@ from pyrogram.errors import BadRequest, ChatAdminRequired, Forbidden
 from pyrogram.types import (
     CallbackQuery,
     Chat,
+    ChatMemberUpdated,
     InlineKeyboardButton,
     InlineKeyboardMarkup,
     Message,
@@ -64,6 +65,26 @@ class Federation(plugin.Plugin):
             banned = await self.is_fbanned(chat.id, new_member.id)
             if banned:
                 await self.fban_handler(message.chat, new_member, banned)
+
+    async def on_chat_member_update(self, update: ChatMemberUpdated) -> Optional[str]:
+        if update.old_chat_member.user.id != self.bot.uid:
+            return
+        if not (update.old_chat_member and update.new_chat_member):
+            return
+
+        if (
+            update.old_chat_member.can_restrict_members
+            and not update.new_chat_member.can_restrict_members
+        ):
+            chat = update.chat
+            fed_data = await self.get_fed_bychat(chat.id)
+            if not fed_data:
+                return
+            ret, _ = await asyncio.gather(
+                self.text(chat.id, "fed-autoleave", fed_data["name"], fed_data["_id"]),
+                self.db.update_one({"_id": fed_data["_id"]}, {"$pull": {"chats": chat.id}}),
+            )
+            await self.bot.client.send_message(chat.id, ret)
 
     @listener.filters(filters.regex(r"(rm|log)fed_(.*)"))
     async def on_callback_query(self, query: CallbackQuery) -> Any:
@@ -230,7 +251,7 @@ class Federation(plugin.Plugin):
         )
         return None
 
-    @command.filters(filters.admin_only)
+    @command.filters(filters.admin_only & filters.can_restrict)
     async def cmd_joinfed(self, ctx: command.Context, fid: Optional[str] = None) -> str:
         """Join a federation in chats"""
         chat = ctx.chat

--- a/language/en.yml
+++ b/language/en.yml
@@ -218,6 +218,7 @@ fed-log-set-chnl: "This channel has been set as the fed log for **{}**\nall fed 
 fed-invalid-identity: The user who clicked confirmation button was not the fed creator.\nOnly the federation creator can set the fed log.
 fed-log-unset: Federation log of **{}** is unset.
 fed-autoban: "User {} is banned in the current federation (**{}**), and has been removed.\n**Reason:** {}\n**Banned on:** {}"
+fed-autoleave: "I no longger have permission to ban members in this chat. Leaving fed \"{}\"(`{}`)"
 #endregion
 #region language
 language-button: Language

--- a/language/id.yml
+++ b/language/id.yml
@@ -216,6 +216,7 @@ fed-log-set-chnl: "Saluran ini telah ditetapkan sebagai catatan federasi untuk *
 fed-invalid-identity: Pengguna yang mengklik tombol konfirmasi bukanlah pemilik federasi.\nHanya pemilik federasi yang dapat menetapkan catatan federasi.
 fed-log-unset: Catatan federasi dari **{}** telah dibatalkan.
 fed-autoban: "Pengguna {} dilarang dalam federasi ini (**{}**), dan sudah dikeluarkan.\n**Reason:** {}\n**Banned on:** {}"
+fed-autoleave: "Saya tidak lagi memiliki izin untuk melarang anggota dalam obrolan ini. Meninggalkan federasi \"{}\"(`{}`)"
 #endregion
 #region language
 language-button: Bahasa


### PR DESCRIPTION
- Add ChatMemberUpdatedHandler.
- Auto leave federation when bot ban permission revoked.
- Leave federation on `/fban` if can't ban member.
- Don't allow `/joinfed` if bot doesn't have ban permission.
