### PR TITLE
Add User-trust score to spam detection

### DIFF
--- a/anjani/plugins/spam_prediction.py
+++ b/anjani/plugins/spam_prediction.py
@@ -55,6 +55,7 @@ except ImportError:
     _run_predict = False
 
 from anjani import command, filters, listener, plugin, util
+from anjani.util.misc import StopPropagation
 
 env = Path("config.env")
 try:
@@ -359,6 +360,7 @@ class SpamPrediction(plugin.Plugin):
             pass
 
     @listener.filters(filters.group)
+    @listener.priority(70)
     async def on_message(self, message: Message) -> None:
         """Checker service for message"""
         setting = await self.setting_db.find_one({"chat_id": message.chat.id})
@@ -549,6 +551,7 @@ class SpamPrediction(plugin.Plugin):
                 reply_to_message_id=reply_id,
                 reply_markup=InlineKeyboardMarkup(button),
             )
+            raise StopPropagation
 
     async def mark_spam_ocr(
         self, content: str, user_id: Optional[int], chat_id: int, message_id: int

--- a/anjani/plugins/users.py
+++ b/anjani/plugins/users.py
@@ -203,7 +203,7 @@ class Users(plugin.Plugin):
         if user_db and self.predict_loaded:
             text += f"\n**Identifier:** `{user_db.get('hash', 'unknown')}`"
             text += f"\n**Reputation:** `{user_db.get('reputation', 0)}`"
-            trust = get_trust(user_db.get("predict_sample", []))
+            trust = get_trust(user_db.get("pred_sample", []))
             if trust:
                 text += f"\n**Trust:** `{trust:.2f}`"
             else:

--- a/anjani/plugins/users.py
+++ b/anjani/plugins/users.py
@@ -201,6 +201,11 @@ class Users(plugin.Plugin):
         if user_db and self.predict_loaded:
             text += f"\n**Identifier:** `{user_db.get('hash', 'unknown')}`"
             text += f"\n**Reputation: **`{user_db.get('reputation', 0)}`"
+            trust = await self.bot.plugins["SpamPredict"].get_trust(user.id)  # type: ignore
+            if trust:
+                text += f"\n**Trust: **`{trust:.2f}`"
+            else:
+                text += "\n**Trust: **`N/A`"
 
         if user.photo:
             async with ctx.action(ChatAction.UPLOAD_PHOTO):

--- a/anjani/plugins/users.py
+++ b/anjani/plugins/users.py
@@ -27,6 +27,8 @@ from pyrogram.types import CallbackQuery, Chat, ChatPreview, Message, User
 
 from anjani import command, plugin, util
 
+from .spam_prediction import get_trust
+
 
 class Users(plugin.Plugin):
     name: ClassVar[str] = "Users"
@@ -200,12 +202,12 @@ class Users(plugin.Plugin):
         user_db = await self.users_db.find_one({"_id": user.id})
         if user_db and self.predict_loaded:
             text += f"\n**Identifier:** `{user_db.get('hash', 'unknown')}`"
-            text += f"\n**Reputation: **`{user_db.get('reputation', 0)}`"
-            trust = await self.bot.plugins["SpamPredict"].get_trust(user.id)  # type: ignore
+            text += f"\n**Reputation:** `{user_db.get('reputation', 0)}`"
+            trust = get_trust(user_db.get("predict_sample", []))
             if trust:
-                text += f"\n**Trust: **`{trust:.2f}`"
+                text += f"\n**Trust:** `{trust:.2f}`"
             else:
-                text += "\n**Trust: **`N/A`"
+                text += "\n**Trust:** `N/A`"
 
         if user.photo:
             async with ctx.action(ChatAction.UPLOAD_PHOTO):


### PR DESCRIPTION
This add a trust score to user computed from the sample that are collected. Trust score is calculated on how the user will likely to send a spam message according to the bot. When user trust score is low (<5.0 *current threshold) bot will ban the user concerned.

**Other**
- Lower spam check priority. This makes sure that are no other plugin get the message update before checking
- Add trust score on `/info`