### PR TITLE
Revamp user 'Reputation Point' utility

### DIFF
--- a/anjani/language/en.yml
+++ b/anjani/language/en.yml
@@ -479,8 +479,11 @@ spampredict-help: |
   For addition we currently developing a spam protection using a machine learning. The bot will detect and delete spam messages from your chats.
   You can also help us to train our model by casting a vote on @SpamPredictionLog. You will earn a reputation point with some benefit in the future 😉.\n
   **Admin Commands:**
-  /spampredict <on/off/yes/no>: Will disable or enable the message spam prediction in your group.\n
-  If enabled, the bot will automaticaly delete and log the message to @SpamPredictionLog.
+  × /spampredict <on/off/yes/no>: Will disable or enable the message spam prediction in your group.\n
+  If enabled, the bot will automaticaly delete and log the message to @SpamPredictionLog.\n
+  **User Commands:**
+  × /predict <reply>: Will predict the message if it's a spam or not*.
+  *this will consume 10 reputation point.
 spampredict-set: "Chat spam prediction turned {}."
 spampredict-view: |
   Spam Prediction Setting: **{}**.
@@ -488,9 +491,10 @@ spampredict-view: |
 spampredict-empty: message/photo text nor caption is empty to predict...
 spampredict-photo: "Reading photo text with ocr...\nThis might take a while."
 spampredict-photo-failed: "__Failed to read photo text with ocr.__\n\n"
-spampredict-unauthorized: |
-  Your reputation point is not enough to use this command! ({}/{})
-  To get a reputation point cast a vote on @SpamPredictionLog.
+spampredict-insuficent: |
+  Insuficent reputation to run prediction! ({}/{}).
+  Prediction will consume {} reputation point.
+  You can earn reputation by voting on @SpamPredictionLog.
 spampredict-failed: Prediction failed...
 spampredict-ban: "{user} has been banned!"
 spampredict-ban-no-perm: You don't have permission to ban users!

--- a/anjani/language/id.yml
+++ b/anjani/language/id.yml
@@ -503,8 +503,11 @@ spampredict-help: |
   Sebagai tambahan, saat ini kami sedang mengembangkan perlindungan spam menggunakan machine learning. Bot akan mendeteksi dan menghapus pesan spam dari grup anda.
   Anda juga dapat membantu kami mendidik model kami dengan memberikan suara di @SpamPredictionLog. Anda akan mendapatkan poin reputasi dengan beberapa manfaat ke depannya 😉.\n
   **Hanya Administrator yang bisa menggunakan:**
-  /spampredict <on/off/yes/no>: Akan mematikan atau menyalakan pengaruh dari perlindungan spam di grup anda.\n
-  Jika dinyalakan, bot akan otomatis menghapus dan mencatat pesan ke @SpamPredictionLog.
+  × /spampredict <on/off/yes/no>: Akan mematikan atau menyalakan pengaruh dari perlindungan spam di grup anda.\n
+  Jika dinyalakan, bot akan otomatis menghapus dan mencatat pesan ke @SpamPredictionLog.\n
+  **Perintah pengguna:**
+  × /predict <balas ke pesan>: Bot akan memprediksi apakah pesan itu spam atau tidak*.
+  *perintah ini akan memakai 10 poin reputasi anda.
 spampredict-set: "Chat spam prediksi berubah ke {}."
 spampredict-view: |
   Spam Prediction Setting: **{}**.
@@ -512,8 +515,9 @@ spampredict-view: |
 spampredict-empty: pesan/photo teks atau keterangan media kosong untuk diprediksi...
 spampredict-photo: "Membaca teks pada foto dengan ocr...\nIni bisa saja membutuhkan waktu lama."
 spampredict-photo-failed: "__Gagal membaca teks pada foto dengan ocr.__\n\n"
-spampredict-unauthorized: |
-  Poin reputasi anda tidak cukup untuk menggunakan perintah ini! ({}/{})
+spampredict-insuficent: |
+  Poin reputasi anda tidak cukup untuk menjalankan perintah prediksi! ({}/{})
+  Prediksi akan memakai {} poin reputasi anda.
   Untuk mendapatkan poin reputasi silahkan berikan suara di @SpamPredictionLog.
 spampredict-failed: Prediksi gagal...
 spampredict-ban: "{user} telah diblokir!"
@@ -523,8 +527,8 @@ spampredict-ban-no-perm: "Kamu tidak punya izin untuk melakukan ini!"
 spamshield-button: Spam Shield
 spamshield-help: |
   **Hanya Administrator yang bisa menggunakan:**
-   /spamshield <on/off/yes/no>: Akan mematikan atau menyalakan pengaruh dari perlindungan spam di grup anda.\n
-   Spam shield menggunakan Combot Anti Spam, API @Spamwatch, dan larangan global untuk menghapus sebanyak mungkin orang yang melakukan spam dari ruang obrolan anda!
+  /spamshield <on/off/yes/no>: Akan mematikan atau menyalakan pengaruh dari perlindungan spam di grup anda.\n
+  Spam shield menggunakan Combot Anti Spam, API @Spamwatch, dan larangan global untuk menghapus sebanyak mungkin orang yang melakukan spam dari ruang obrolan anda!
 banned-text: |
   #SPAM_SHIELD\n
   **Nama:** {}

--- a/anjani/plugins/spam_prediction.py
+++ b/anjani/plugins/spam_prediction.py
@@ -408,7 +408,7 @@ class SpamPrediction(plugin.Plugin):
             user = None
 
         text_norm = self._normalize_text(text)
-        if len(text_norm.split()) < 5:  # Skip short messages
+        if len(text_norm.split()) < 4:  # Skip short messages
             return
 
         response = await self._predict(text_norm)

--- a/anjani/plugins/spam_prediction.py
+++ b/anjani/plugins/spam_prediction.py
@@ -92,7 +92,7 @@ class SpamPrediction(plugin.Plugin):
     user_db: util.db.AsyncCollection
     setting_db: util.db.AsyncCollection
     model: Pipeline
-    __min_reputation: int = 300
+    __predict_cost: int = 10
 
     async def on_load(self) -> None:
         self.db = self.bot.db.get_collection("SPAM_DUMP")
@@ -703,12 +703,12 @@ class SpamPrediction(plugin.Plugin):
         if not user:
             return None
 
-        if user.get("reputation", 0) < self.__min_reputation:
+        if user.get("reputation", 0) < self.__predict_cost:
             return await self.text(
                 chat.id,
                 "spampredict-unauthorized",
                 user.get("reputation", 0),
-                self.__min_reputation,
+                self.__predict_cost,
             )
 
         replied = ctx.msg.reply_to_message
@@ -740,6 +740,10 @@ class SpamPrediction(plugin.Plugin):
                         await asyncio.gather(
                             self.bot.log_stat("predicted"),
                             ctx.respond(photo_prediction),
+                            self.user_db.update_one(
+                                {"_id": ctx.author.id},
+                                {"$inc": {"reputation": -self.__predict_cost}},
+                            ),
                         )
                         return None
             else:
@@ -765,6 +769,9 @@ class SpamPrediction(plugin.Plugin):
                 if photo_prediction
                 else "**Result**\n\n" + textPrediction,
                 reply_to_message_id=None if replied.photo else replied.id,
+            ),
+            self.user_db.update_one(
+                {"_id": ctx.author.id}, {"$inc": {"reputation": -self.__predict_cost}}
             ),
         )
         return None


### PR DESCRIPTION
This remove a reputation requirement of (300) to run prediction '/predict'
and makes a manual prediction '/predict' cost a reputation point (currently 10).