### PR TITLE
Add plugin flag to quickly disable plugin

### DIFF
--- a/anjani/core/plugin_extenter.py
+++ b/anjani/core/plugin_extenter.py
@@ -69,7 +69,9 @@ class PluginExtender(MixinBase):
             for sym in dir(plug):
                 cls = getattr(plug, sym)
                 if inspect.isclass(cls) and issubclass(cls, plugin.Plugin) and not cls.disabled:
-                    self.load_plugin(cls, comment=comment)
+                    name = cls.name.lower().replace(" ", "_")
+                    if self.config.is_plugin_disabled(f"disable_{name}_plugin"):
+                        self.load_plugin(cls, comment=comment)
 
     # noinspection PyTypeChecker,PyTypeChecker
     def load_all_plugins(self: "Anjani") -> None:

--- a/anjani/core/plugin_extenter.py
+++ b/anjani/core/plugin_extenter.py
@@ -70,7 +70,7 @@ class PluginExtender(MixinBase):
                 cls = getattr(plug, sym)
                 if inspect.isclass(cls) and issubclass(cls, plugin.Plugin) and not cls.disabled:
                     name = cls.name.lower().replace(" ", "_")
-                    if self.config.is_plugin_disabled(f"disable_{name}_plugin"):
+                    if not self.config.is_plugin_disabled(f"disable_{name}_plugin"):
                         self.load_plugin(cls, comment=comment)
 
     # noinspection PyTypeChecker,PyTypeChecker

--- a/anjani/main.py
+++ b/anjani/main.py
@@ -125,6 +125,7 @@ def start() -> None:
         "sw_api": os.environ.get("SW_API"),
         "log_channel": os.environ.get("LOG_CHANNEL"),
         "login_url": os.environ.get("LOGIN_URL"),
+        "plugin_flag": [i.strip() for i in os.environ.get("PLUGIN_FLAG", "").split(";")],
     }
     config: TelegramConfig[str, str] = TelegramConfig(config_data)
     if any(key not in config for key in {"api_id", "api_hash", "bot_token", "db_uri"}):

--- a/anjani/util/config.py
+++ b/anjani/util/config.py
@@ -29,7 +29,7 @@ class TelegramConfig(MutableMapping[_KT, _VT]):
             super().__setattr__(key, value)
 
     def is_plugin_disabled(self, name: str) -> bool:
-        return name not in self.__getattribute__("plugin_flag")
+        return name in self.__getattribute__("plugin_flag")
 
     def __contains__(self, k: _KT) -> bool:
         return k in self.__dict__

--- a/anjani/util/config.py
+++ b/anjani/util/config.py
@@ -28,6 +28,9 @@ class TelegramConfig(MutableMapping[_KT, _VT]):
 
             super().__setattr__(key, value)
 
+    def is_plugin_disabled(self, name: str) -> bool:
+        return name not in self.__getattribute__("plugin_flag")
+
     def __contains__(self, k: _KT) -> bool:
         return k in self.__dict__
 

--- a/config.env_sample
+++ b/config.env_sample
@@ -24,6 +24,18 @@ DB_URI=""
 
 # ---- OPTIONAL ---- #
 
+# Flags for disabling some plugin
+# value are seperated by ';' and mus follow this format 'disable_<plugin_name>_plugin'
+# change the <plugin_name> to the plugin name you want to disable.
+# must matched then name attribute of the plugin, repplace whitespace with underscore and lowercased
+# example:
+# class PluginA():
+#     name: ClassVar[str] = "The Name"
+#
+# then the value are 'disable_the_name_plugin'
+PLUGIN_FLAG="disable_spampredict_plugin;disable_canonical_plugin"
+
+
 # Number of maximum worker for handling incoming updates.
 # Defaults to pyrogram's default value: min(32, os.cpu_count() + 4)
 # WORKERS=16
@@ -33,7 +45,7 @@ DB_URI=""
 DOWNLOAD_PATH="./downloads/"
 
 # Spamwatch API
-SW_API = ""
+SW_API=""
 
 # Bot log channel
 # Also Known as the message dump


### PR DESCRIPTION
Add an environment flag to disable a plugin. This simplify a plugin disabling from editing on the source code to the env scope.
Environment `PLUGIN_FLAG` will be added with `disable_{feature}_plugin` schema

```shell
PLUGIN_FLAG="disable_canonical_plugin;disable_spam_prediction_plugin"
```

Flags are separated by ';' character. Flag must match `disable_{plugin_name}_plugin` schema where `{plugin_name}` is declared on the `Plugin.name` property

Example:
```python
class PluginA():
    name: ClassVar[str] = "The Name"
```
then the flag would be `disable_then_name_plugin`

<details><summary>Related Issue</summary>
userbotindo/backlog#2
</details>