### PR TITLE
fix(filter|notes): handle unsuported character

### DIFF
--- a/anjani/language/en.yml
+++ b/anjani/language/en.yml
@@ -607,4 +607,5 @@ err-perm: We are not administrator of this group.
 err-unexpected: "An unexpected error occurred.! \n\n**Error:** `{}`"
 err-msg-format-parsing: "**Message format parsing error!**\n**Error on key:** `{err}`."
 err-im-not-admin: "I'm not an admin here! I need to be an admin to do this."
+err-illegal-trigger: "Illegal character in trigger!\n'.' and '$' are not allowed"
 #endregion

--- a/anjani/language/id.yml
+++ b/anjani/language/id.yml
@@ -631,4 +631,5 @@ err-perm: Saya dan Anda bukan administrator pada group ini.
 err-unexpected: "Telah terjadi kesalahan yang tak terduga!\n\n**Error:** `{}`"
 err-msg-format-parsing: "**Terjadi kesalahan penguraian format pesan!**\n**Kesalahan pada kunci:** `{err}`."
 err-im-not-admin: Saya bukan administrator di sini! Saya membutuhkan hak administrator untuk melakukan ini.
+err-illegal-trigger: "Karakter ilegal pada kata kunci!\n'.' dan '$' tidak diperbolehkan"
 #endregion

--- a/anjani/plugins/filters.py
+++ b/anjani/plugins/filters.py
@@ -16,13 +16,22 @@
 
 import asyncio
 import re
-from typing import Any, ClassVar, MutableMapping, Optional, Set, Tuple, Coroutine, Callable
+from typing import (
+    Any,
+    Callable,
+    ClassVar,
+    Coroutine,
+    MutableMapping,
+    Optional,
+    Set,
+    Tuple,
+)
 
-from pyrogram.types import Message
 from pyrogram.errors import MediaEmpty, MessageEmpty
+from pyrogram.types import Message
 
 from anjani import command, filters, listener, plugin, util
-from anjani.util.tg import Types, get_message_info, build_button
+from anjani.util.tg import Types, build_button, get_message_info
 
 
 class Filters(plugin.Plugin):
@@ -175,6 +184,10 @@ class Filters(plugin.Plugin):
             return await self.text(chat.id, "filter-help")
 
         trigger = ctx.args[0]
+
+        if "." in trigger or "$" in trigger:
+            return await self.text(chat.id, "err-illegal-trigger")
+
         text, types, content, buttons = get_message_info(ctx.msg)
         _, ret = await asyncio.gather(
             self.db.update_one(

--- a/anjani/plugins/notes.py
+++ b/anjani/plugins/notes.py
@@ -175,7 +175,10 @@ class Notes(plugin.Plugin):
             )
             return
 
-        name = ctx.args[0]
+        trigger = ctx.args[0]
+        if trigger.startswith("#") or "." in trigger or "$" in trigger:
+            return await self.text(chat.id, "err-illegal-trigger")
+
         text, types, content, buttons = get_message_info(ctx.msg)
         _, ret = await asyncio.gather(
             self.db.update_one(
@@ -183,7 +186,7 @@ class Notes(plugin.Plugin):
                 {
                     "$set": {
                         "chat_name": chat.title,
-                        f"notes.{name}": {
+                        f"notes.{trigger}": {
                             "text": text,
                             "type": types,
                             "content": content,
@@ -193,7 +196,7 @@ class Notes(plugin.Plugin):
                 },
                 upsert=True,
             ),
-            self.text(chat.id, "note-saved", name),
+            self.text(chat.id, "note-saved", trigger),
         )
         return ret
 


### PR DESCRIPTION
close #216

This force trigger to not have '.' and '$' character for notes and filters