### PR TITLE
Add cache wrapper to method with high traffic

### DIFF
--- a/anjani/core/telegram_bot.py
+++ b/anjani/core/telegram_bot.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Any, MutableMapping, Optional, Set, Tuple, Typ
 
 import pyrogram.filters as flt
 from aiopath import AsyncPath
+from cache import AsyncTTL
 from pyrogram.client import Client
 from pyrogram.enums.parse_mode import ParseMode
 from pyrogram.filters import Filter
@@ -30,7 +31,15 @@ from pyrogram.handlers.callback_query_handler import CallbackQueryHandler
 from pyrogram.handlers.chat_member_updated_handler import ChatMemberUpdatedHandler
 from pyrogram.handlers.inline_query_handler import InlineQueryHandler
 from pyrogram.handlers.message_handler import MessageHandler
-from pyrogram.types import CallbackQuery, InlineQuery, Message, User
+from pyrogram.types import (
+    CallbackQuery,
+    Chat,
+    ChatMember,
+    ChatPreview,
+    InlineQuery,
+    Message,
+    User,
+)
 from yaml import full_load
 
 from anjani import util
@@ -352,3 +361,13 @@ class TelegramBot(MixinBase):
             return await response.edit(text, **kwargs)
 
         raise ValueError(f"Unknown response mode {mode}")
+
+    @AsyncTTL(time_to_live=60, maxsize=1024)
+    async def get_chat(self: "Anjani", chat_id: int) -> Union[Chat, ChatPreview]:
+        """Wrapper for `Client.get_chat` with a TTL cache."""
+        return await self.client.get_chat(chat_id)
+
+    @AsyncTTL(time_to_live=60, maxsize=1024)
+    async def get_chat_member(self: "Anjani", chat_id: int, user_id: int) -> ChatMember:
+        """Wrapper for `Client.get_chat_member` with a TTL cache."""
+        return await self.client.get_chat_member(chat_id, user_id)

--- a/anjani/plugins/lockings.py
+++ b/anjani/plugins/lockings.py
@@ -144,7 +144,7 @@ class Lockings(plugin.Plugin):
             if message.sender_chat.id == chat.id:  # anon admin
                 return
 
-            current_chat: Any = await self.bot.client.get_chat(chat.id)
+            current_chat: Any = await self.bot.get_chat(chat.id)
             if current_chat.linked_chat and message.sender_chat.id == current_chat.linked_chat.id:
                 # Linked channel group
                 return

--- a/anjani/plugins/spam_prediction.py
+++ b/anjani/plugins/spam_prediction.py
@@ -511,7 +511,7 @@ class SpamPrediction(plugin.Plugin):
                 if message.sender_chat.id == chat.id:  # anon admin
                     return
 
-                current_chat: Any = await self.bot.client.get_chat(chat.id)
+                current_chat: Any = await self.bot.get_chat(chat.id)
                 if (
                     current_chat.linked_chat
                     and message.sender_chat.id == current_chat.linked_chat.id

--- a/poetry.lock
+++ b/poetry.lock
@@ -231,6 +231,17 @@ wrapt = [
 ]
 
 [[package]]
+name = "async-cache"
+version = "1.1.1"
+description = "An asyncio Cache"
+category = "main"
+optional = false
+python-versions = ">=3.3"
+files = [
+    {file = "async-cache-1.1.1.tar.gz", hash = "sha256:81aa9ccd19fb06784aaf30bd5f2043dc0a23fc3e998b93d0c2c17d1af9803393"},
+]
+
+[[package]]
 name = "async-timeout"
 version = "4.0.2"
 description = "Timeout context manager for asyncio programs"
@@ -1805,4 +1816,4 @@ uvloop = ["uvloop"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~=3.9"
-content-hash = "47a24e04adc8437bc7d3588caac974f75b480a328fcf97cd424b91bd32bb7919"
+content-hash = "c56310debe6b7ab11bf97499002ea8ba2ecc0da07f4fc2973c785a201fcfdfe5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ TgCrypto = "^1.2.5"
 typing-extensions = "^4.5.0"
 uvloop = {version = "^0.17.0", optional = true, platform = "linux"}
 yarl = "^1.8.2"
+async-cache = "^1.1.1"
 
 [tool.poetry.extras]
 all = ["scikit-learn", "uvloop"]


### PR DESCRIPTION
Calling Pyrogram `get_xxx()` when the traffic is high raise many `FLOOD_WAIT` exception thus many plugin depends on this. This add a cache wrapper to several method/functions and implement 60 seconds TTL.

- add [async-cache](https://pypi.org/project/async-cache/) deps.
- add wrapper for `Client.get_chat()`
- add wrapper for `Client.get_chat_member()`


<details>
<summary>Related Issue</summary>
<br>
userbotindo/backlog#1

userbotindo/backlog#4
</details>